### PR TITLE
Corrected typo in Definition 1.3

### DIFF
--- a/chapter1/chapter1_forInclude.tex
+++ b/chapter1/chapter1_forInclude.tex
@@ -100,7 +100,7 @@ An event space associated with a sample space $ \Omega $ is a set $ \mathcal{A} 
 \begin{enumerate}
 \item $ \mathcal{A} $ is non-empty
 \item If $ A \in \mathcal{A} $ then $ A \subseteq \Omega $
-\item If $ A \in \mathcal{A} $ then $ \Omega\backslash \mathcal{A} \in \mathcal{A} $
+\item If $ A \in \mathcal{A} $ then $ \Omega \setminus A \in \mathcal{A} $
 \item If $ A,B \in \mathcal{A} $ then $ A \cup B \in \mathcal{A} $
 \end{enumerate}
 \end{Definition}


### PR DESCRIPTION
Corrected typo on page 4 in Definition 1.3. In the third condition of the definition of a Sample space it was stated:
"\item If $ A \in \mathcal{A} $ then $ \Omega\backslash \mathcal{A} \in \mathcal{A} $".
This should be: "\item If $A \in \mathcal{A}$ then $\Omega \setminus A \in \mathcal{A}$".
